### PR TITLE
Fixes credentials block import examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed wrong import of `EarthdataCredentials` in code examples - [#20](https://github.com/giorgiobasile/prefect-earthdata/issues/20)
+
 ### Security
 
 ## 0.1.0

--- a/prefect_earthdata/credentials.py
+++ b/prefect_earthdata/credentials.py
@@ -20,7 +20,7 @@ class EarthdataCredentials(Block):
     Example:
         Load stored Earthdata credentials:
         ```python
-        from prefect_earthdata import EarthdataCredentials
+        from prefect_earthdata.credentials import EarthdataCredentials
 
         ed_credentials_block = EarthdataCredentials.load("BLOCK_NAME")
         ```
@@ -50,7 +50,7 @@ class EarthdataCredentials(Block):
             Authenticates with NASA Earthdata using the credentials.
 
             ```python
-            from prefect_earthdata.earthdata import EarthdataCredentials
+            from prefect_earthdata.credentials import EarthdataCredentials
 
             earthdata_credentials_block = EarthdataCredentials(
                 earthdata_username = "username",


### PR DESCRIPTION
<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes #20 

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

The right import is documented as:

```python
from prefect_earthdata.credentials import EarthdataCredentials
```

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [x] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/giorgiobasile/prefect-earthdata/issues/new/choose) first.
- [x] Includes tests or only affects documentation.
- [x] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [x] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [x] Summarizes PR's changes in [CHANGELOG.md](https://github.com/giorgiobasile/prefect-earthdata/blob/main/CHANGELOG.md)
